### PR TITLE
Use wake up pin that is not dependent on analog power

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           compliance: specification
-          library-manager: submit
+          library-manager: update
           # Always use this setting for official repositories. Remove for 3rd party projects.
           official: true
           project-type: library

--- a/examples/WakeFromPin/WakeFromPin.ino
+++ b/examples/WakeFromPin/WakeFromPin.ino
@@ -32,6 +32,7 @@
 #define WAKE_PIN A3 // Pin used to wake up the device
 
 LowPower lowPower;
+bool shouldSleep = false;
 
 #ifdef TURN_PERIPHERALS_OFF
     #include "Arduino_PMIC.h"
@@ -56,13 +57,7 @@ LowPower lowPower;
 #endif
 
 void goToSleep(){
-    // Turn off the built-in LED before going to sleep
-    digitalWrite(LED_BUILTIN, HIGH);
-
-    #ifdef TURN_PERIPHERALS_OFF
-        turnPeripheralsOff();
-    #endif
-    lowPower.deepSleep(); 
+    shouldSleep = true;
 }
 
 void setup(){
@@ -83,6 +78,17 @@ void setup(){
 }
 
 void loop(){
+    if(shouldSleep){
+        // Turn off the built-in LED before going to sleep
+        digitalWrite(LED_BUILTIN, HIGH);
+
+        #ifdef TURN_PERIPHERALS_OFF
+            turnPeripheralsOff();
+        #endif
+        lowPower.deepSleep(); 
+        shouldSleep = false;
+    }
+
     // Blink the built-in LED every 500ms when the device is not sleeping    
     digitalWrite(LED_BUILTIN, LOW);
     delay(500);

--- a/examples/WakeFromPin/WakeFromPin.ino
+++ b/examples/WakeFromPin/WakeFromPin.ino
@@ -34,7 +34,14 @@
 
 // #define TURN_PERIPHERALS_OFF // Uncomment this line to turn off the peripherals before going to sleep
 #define SLEEP_PIN D0 // Pin used to put the device to sleep
-#define WAKE_PIN A3 // Pin used to wake up the device
+
+/*
+The following pins can be used to wake up the device: A0, A1, A2, A3, A4, A5, D4, D7
+However turnPeripheralsOff() in this sketch turns off the power lane of the analog pins.
+This means they cannot sink current and therefore cannot be used to wake up the device. 
+Hency only D4 and D7 can be used to wake up the device in this configuration.
+*/
+#define WAKE_PIN D4
 
 LowPower lowPower;
 bool shouldSleep = false;

--- a/examples/WakeFromPin/WakeFromPin.ino
+++ b/examples/WakeFromPin/WakeFromPin.ino
@@ -19,7 +19,12 @@
 * - Select the Portenta C33's USB port from the Tools menu
 * - Upload the code to your Portenta C33
 * - Connect a button to pin D0 and ground with a pull-up resistor to 3.3V
-* - Connect a button to pin A3 and ground with a pull-up resistor to 3.3V 
+* - Connect a button to pin D4 and ground with a pull-up resistor to 3.3V 
+*   
+*   For maximum power saving use external pull-up resistors.
+*   You will need to power them separately as the 3.3V pin on the board 
+*   is turned off when the device goes to sleep and TURN_PERIPHERALS_OFF is enabled.
+*   Alternatively, use pinMode(<pin>, INPUT_PULLUP) for the pins and connect the buttons to ground.
 * (If you need information about how to wire the buttons check this link: https://docs.arduino.cc/built-in-examples/digital/Button/)
 * 
 * Initial author: C. Dragomir
@@ -61,7 +66,7 @@ void goToSleep(){
 }
 
 void setup(){
-    // External pull-up resistor used for the buttons
+    // External pull-up resistor used for the buttons for maximum power saving
     pinMode(SLEEP_PIN, INPUT);
     pinMode(WAKE_PIN, INPUT);
 


### PR DESCRIPTION
The previous version of the example sketch `WakeFromPin.ino` used an analog pin for the wake-up. However, the function that turns off the peripherals also turns off power to the analog pins. As a result they cannot sink current even when using an external pull-up resistor, it doesn't work. This PR changes the example so that it uses a digital pin for the wake up.
Also, interacting with the PMIC in the interrupt handler caused the PMIC to not always turn off the lanes. Moving it into the application loop solves this.